### PR TITLE
[iOS] Fixed onScroll prop in mulitline TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -27,6 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)textInputDidChangeSelection;
 
+@optional
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -213,6 +213,15 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   [self textViewProbablyDidChangeSelection];
 }
 
+#pragma mark - UIScrollViewDelegate
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+  if ([_backedTextInputView.textInputDelegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
+    [_backedTextInputView.textInputDelegate scrollViewDidScroll:scrollView];
+  }
+}
+
 #pragma mark - Public Interface
 
 - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
We lose the support of onScroll prop for multiline TextInput, let's add it again.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[iOS] [Fixed] - Fixed onScroll prop in mulitline TextInput

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

## Test Plan
Code like below can trigger onScroll event:
```
<TextInput style={{height:50}} onScroll={() => {
              console.log('onScroll!');
            }}
  multiline={true}
/>
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
